### PR TITLE
Topological sorting with RcTerm to reduce redundant calculation

### DIFF
--- a/examples/rc_animation.rs
+++ b/examples/rc_animation.rs
@@ -33,6 +33,6 @@ fn main() {
     };
     abc.eval_cb(&callback);
 
-    abc.backprop_cb(&callback);
+    abc.backprop_cb(&callback).unwrap();
     abc.dot(&mut std::io::stdout()).unwrap();
 }

--- a/examples/rc_arithm.rs
+++ b/examples/rc_arithm.rs
@@ -22,6 +22,6 @@ fn main() {
     let abcd_c = abcd.derive(&c);
     println!("d((a + b) * c / d) / dc = {}", abcd_c);
 
-    abcd.backprop();
+    abcd.backprop().unwrap();
     abcd.dot(&mut std::io::stdout()).unwrap();
 }

--- a/examples/rc_curve_fit.rs
+++ b/examples/rc_curve_fit.rs
@@ -38,7 +38,7 @@ fn main() {
             model.x.set(xval).unwrap();
             model.sample_y.set(sample_y).unwrap();
             model.loss.eval();
-            model.loss.backprop();
+            model.loss.backprop().unwrap();
             *mu -= RATE * model.mu.grad();
             *sigma -= RATE * model.sigma.grad();
             *scale -= RATE * model.scale.grad();
@@ -107,7 +107,7 @@ fn main() {
     model.loss.clear();
     model.loss.clear_grad();
     model.loss.eval_cb(&callback);
-    model.loss.backprop_cb(&callback);
+    model.loss.backprop_cb(&callback).unwrap();
     let mut dotfile = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
     model.loss.dot(&mut dotfile).unwrap();
 }

--- a/examples/rc_diamond.rs
+++ b/examples/rc_diamond.rs
@@ -23,7 +23,7 @@ fn main() {
     };
 
     abac.eval_cb(&callback);
-    abac.backprop_cb(&callback);
+    abac.backprop_cb(&callback).unwrap();
     println!("abac: {}", abac.grad());
     println!("a: {}", a.grad());
     println!("b: {}", b.grad());

--- a/examples/rc_sigmoid.rs
+++ b/examples/rc_sigmoid.rs
@@ -16,7 +16,7 @@ fn main() {
     }
     x.set(0.).unwrap();
     all.eval();
-    all.backprop();
+    all.backprop().unwrap();
     all.dot(&mut std::io::stdout()).unwrap();
 }
 

--- a/examples/rc_tensor_curve_fit.rs
+++ b/examples/rc_tensor_curve_fit.rs
@@ -214,7 +214,12 @@ fn main() {
         let i = counter.get();
         let mut file =
             std::io::BufWriter::new(std::fs::File::create(format!("dot{i}.dot")).unwrap());
-        model.loss.dot(&mut file).unwrap();
+        model
+            .loss
+            .dot_builder()
+            .show_values(false)
+            .dot(&mut file)
+            .unwrap();
         counter.set(i + 1);
     };
 

--- a/examples/rc_tensor_curve_fit.rs
+++ b/examples/rc_tensor_curve_fit.rs
@@ -154,7 +154,7 @@ fn main() {
         model.x.set(MyTensor(samples.clone())).unwrap();
         model.sample_y.set(MyTensor(truth_data.clone())).unwrap();
         model.loss.eval();
-        model.loss.backprop();
+        model.loss.backprop().unwrap();
         *mu -= RATE * model.mu.grad().0.iter().sum::<f64>();
         *sigma -= RATE * model.sigma.grad().0.iter().sum::<f64>();
         *scale -= RATE * model.scale.grad().0.iter().sum::<f64>();
@@ -222,7 +222,7 @@ fn main() {
     model.loss.clear();
     model.loss.clear_grad();
     model.loss.eval_cb(&callback);
-    model.loss.backprop_cb(&callback);
+    model.loss.backprop_cb(&callback).unwrap();
     let mut dotfile = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
     model
         .loss


### PR DESCRIPTION
It is a similar issue to #1, but is for RcTerm instead of TapeTerm.

When we use a tree graph using RcTerm, we need to apply topological sorting to remove redundancy. In a tape, it is automatically done on construction of the tape (which is the whole point of the data structure). However, RcTerm is not a tape, so it needs a topological sorting before applying backprop.

Technically, again, it is not _necessary_, as I mentioned in #1, it's _not wrong_ to not having topological sorted order, but we will redundantly visit the same subtrees multiple times.

Here is the animation of visiting order with RcTerm now.

![backprop](https://github.com/msakuta/rustograd/assets/2798715/aadee604-d5a5-4ee4-b569-8f08ebdd0a45)

