### PR TITLE
Fixes #4 Add Dvec type that allows higher order automatic differentiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ fn sin(x: f64) -> f64 { x.sin() }
 fn sin_derive(x: f64) -> f64 { x.cos() }
 ```
 
+## `Dvec` type for higher order differentiation
+
+`*Term` types do not support higher order differentiation. It's hard to support them in reverse-mode automatic differentiation, and they require a buffer size proportional to the maximum order of differentiation you would want to calculate, so it is inefficient to allocate memory for all of them.
+
+This library provides with `Dvec` type, which is a direct translation from a paper [^1].
+
+[^1]: [Higher Order Automatic Differentiation with Dual Numbers](https://pp.bme.hu/eecs/article/download/16341/8918/87511)
+
+You can find a usage example [with scalars](examples/dvec.rs) and [with tensors](examples/dvec_tensor.rs) in the examples directory.
+
+
 ## Example applications
 
 In the following examples, I use `TapeTerm` because it is expected to be the most efficient one in complex expressions.

--- a/examples/dvec.rs
+++ b/examples/dvec.rs
@@ -1,0 +1,18 @@
+use std::io::Write;
+
+use rustograd::Dvec;
+
+fn main() {
+    let mut f = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    writeln!(f, "x, exp(-x^2), d exp(-x^2)/dx, d^2 exp(-x^2)/dx^2").unwrap();
+    for i in -40..40 {
+        let x = i as f64 / 10.;
+        let d1 = Dvec::new_n(x, 1., 2);
+        let d2 = &d1 * &d1;
+        let d3 = -&d2;
+        let d4 = d3.exp();
+        // let d3 = d2.sin();
+        let res = d4;
+        writeln!(f, "{x}, {}, {}, {}", res[0], res[1], res[2]).unwrap();
+    }
+}

--- a/examples/dvec.rs
+++ b/examples/dvec.rs
@@ -4,15 +4,29 @@ use rustograd::Dvec;
 
 fn main() {
     let mut f = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
-    writeln!(f, "x, exp(-x^2), d exp(-x^2)/dx, d^2 exp(-x^2)/dx^2").unwrap();
+    writeln!(
+        f,
+        "x, exp(-x^2), d exp(-x^2)/dx, d^2 exp(-x^2)/dx^2, d^3 exp(-x^2)/dx^3"
+    )
+    .unwrap();
     for i in -40..40 {
         let x = i as f64 / 10.;
-        let d1 = Dvec::new_n(x, 1., 2);
+        let d1 = Dvec::new_n(x, 1., 3);
         let d2 = &d1 * &d1;
         let d3 = -&d2;
-        let d4 = d3.exp();
+        // let d4 = d3.exp();
+        // let d4 = d1.apply(|x, n| {
+        //     match n % 4 {
+        //         0 => x.sin(),
+        //         1 => x.cos(),
+        //         2 => -x.sin(),
+        //         3 => -x.cos(),
+        //         _ => unreachable!(),
+        //     }
+        // });
+        let d4 = d3.apply(|x, _| x.exp());
         // let d3 = d2.sin();
         let res = d4;
-        writeln!(f, "{x}, {}, {}, {}", res[0], res[1], res[2]).unwrap();
+        writeln!(f, "{x}, {}, {}, {}, {}", res[0], res[1], res[2], res[3]).unwrap();
     }
 }

--- a/examples/dvec_tensor.rs
+++ b/examples/dvec_tensor.rs
@@ -1,0 +1,140 @@
+use std::{fmt::Display, io::Write, ops::Range};
+
+use rustograd::{Dvec, Tensor};
+
+#[derive(Clone)]
+struct MyTensor(Vec<f64>);
+
+const XRANGE: Range<i32> = -40..40;
+const ELEMS: usize = (XRANGE.end - XRANGE.start) as usize;
+
+impl MyTensor {
+    fn map(&self, f: impl Fn(f64) -> f64) -> Self {
+        Self(self.0.iter().map(|&v| f(v)).collect())
+    }
+}
+
+impl Display for MyTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for item in &self.0 {
+            write!(f, "{item}, ")?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for MyTensor {
+    fn default() -> Self {
+        Self(vec![0.; ELEMS])
+    }
+}
+
+impl std::ops::Add for MyTensor {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(
+            self.0
+                .into_iter()
+                .zip(rhs.0.into_iter())
+                .map(|(lhs, rhs)| lhs + rhs)
+                .collect(),
+        )
+    }
+}
+
+impl std::ops::AddAssign for MyTensor {
+    fn add_assign(&mut self, rhs: Self) {
+        for (rhs, lhs) in self.0.iter_mut().zip(rhs.0.into_iter()) {
+            *rhs += lhs;
+        }
+    }
+}
+impl std::ops::Sub for MyTensor {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(
+            self.0
+                .into_iter()
+                .zip(rhs.0.into_iter())
+                .map(|(lhs, rhs)| lhs - rhs)
+                .collect(),
+        )
+    }
+}
+
+impl std::ops::Mul for MyTensor {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(
+            self.0
+                .into_iter()
+                .zip(rhs.0.into_iter())
+                .map(|(lhs, rhs)| lhs * rhs)
+                .collect(),
+        )
+    }
+}
+
+impl std::ops::Div for MyTensor {
+    type Output = Self;
+    fn div(self, rhs: Self) -> Self::Output {
+        Self(
+            self.0
+                .into_iter()
+                .zip(rhs.0.into_iter())
+                .map(|(lhs, rhs)| lhs / rhs)
+                .collect(),
+        )
+    }
+}
+
+impl std::ops::Neg for MyTensor {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self(self.0.into_iter().map(|lhs| -lhs).collect())
+    }
+}
+
+impl Tensor for MyTensor {
+    fn one() -> Self {
+        Self(vec![1.; ELEMS])
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.iter().all(|v| *v == 0.)
+    }
+}
+
+fn main() {
+    let mut f = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    writeln!(
+        f,
+        "x, exp(-x^2), d exp(-x^2)/dx, d^2 exp(-x^2)/dx^2, d^3 exp(-x^2)/dx^3"
+    )
+    .unwrap();
+    let xs = MyTensor(XRANGE.map(|i| i as f64 / 10.).collect());
+    let d1 = Dvec::new_n(xs.clone(), MyTensor::one(), 3);
+    let d2 = &d1 * &d1;
+    let d3 = -&d2;
+    let d4 = d3.apply(|x, _| x.map(f64::exp));
+    // let d4 = d1.apply(|x, n| {
+    //     match n % 4 {
+    //         0 => x.map(f64::sin),
+    //         1 => x.map(f64::cos),
+    //         2 => -x.map(f64::sin),
+    //         3 => -x.map(f64::cos),
+    //         _ => unreachable!(),
+    //     }
+    // });
+    let res = d4;
+
+    for ((((x, y), dy), d2y), d3y) in
+        xs.0.iter()
+            .zip(res[0].0.iter())
+            .zip(res[1].0.iter())
+            .zip(res[2].0.iter())
+            .zip(res[3].0.iter())
+    {
+        writeln!(f, "{x}, {}, {}, {}, {}", y, dy, d2y, d3y).unwrap();
+    }
+}

--- a/src/dnum.rs
+++ b/src/dnum.rs
@@ -1,8 +1,6 @@
-
-
 #[derive(Clone, Copy, PartialEq, Debug)]
 /// An implementation of order N dual nuumber, translated from C++ in a paper [^1]
-/// 
+///
 /// [^1]: Higher Order Automatic Differentiation with Dual Numbers (doi: https://doi.org/10.3311/PPee.16341)
 pub struct Dnum<const N: usize> {
     f: [f64; N], // value and derivatives

--- a/src/dnum.rs
+++ b/src/dnum.rs
@@ -1,0 +1,110 @@
+
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+/// An implementation of order N dual nuumber, translated from C++ in a paper [^1]
+/// 
+/// [^1]: Higher Order Automatic Differentiation with Dual Numbers (doi: https://doi.org/10.3311/PPee.16341)
+pub struct Dnum<const N: usize> {
+    f: [f64; N], // value and derivatives
+}
+
+impl<const N: usize> Dnum<N> {
+    pub fn new(v: f64, d: f64) -> Self {
+        assert!(
+            2 <= N,
+            "This constructor can only be used with 2 or more dual numbers"
+        );
+        let mut f = [0.; N];
+        f[0] = v;
+        f[1] = d;
+        Self { f }
+    }
+
+    pub fn is_real(&self) -> bool {
+        self.f.iter().skip(1).all(|&j| j == 0.)
+    }
+
+    pub fn conjugate(&self) -> Self {
+        let mut res = [0.; N];
+        for (resv, selfv) in res.iter_mut().zip(self.f.iter()).skip(1) {
+            *resv = -selfv;
+        }
+        res[0] = self.f[0];
+        Self { f: res }
+    }
+}
+
+impl<const N: usize> std::ops::Add for Dnum<N> {
+    type Output = Self;
+    fn add(self, rhs: Dnum<N>) -> Self::Output {
+        let mut f = [0.; N];
+        for ((fv, selfv), rhsv) in f.iter_mut().zip(self.f.into_iter()).zip(rhs.f.into_iter()) {
+            *fv = selfv + rhsv;
+        }
+        Self { f }
+    }
+}
+
+impl<const N: usize> std::ops::Div<f64> for Dnum<N> {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self::Output {
+        let mut f = self.f;
+        f.iter_mut().for_each(|j| *j = *j / rhs);
+        Self { f }
+    }
+}
+
+impl<const N: usize> std::ops::Mul for Dnum<N> {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut f = [0.; N];
+        for j in 0..N {
+            for k in 0..N {
+                if j + k < N {
+                    f[j + k] += self.f[j] * rhs.f[k] * choose(j + k, j) as f64;
+                }
+            }
+        }
+        Self { f }
+    }
+}
+
+#[test]
+fn test_dual() {
+    let d1 = Dnum::<2>::new(1., 2.);
+    let d2 = Dnum::<2>::new(3., 4.);
+    assert_eq!(d1 + d2, Dnum::<2>::new(4., 6.));
+
+    let d3 = Dnum::<3> { f: [1., 2., 3.] };
+    assert_eq!(d3.conjugate(), Dnum::<3> { f: [1., -2., -3.] });
+    assert_eq!(d3 / 2., Dnum::<3> { f: [0.5, 1., 1.5] });
+
+    let d4 = Dnum::<2>::new(1., 2.);
+    let d5 = Dnum::<2>::new(10., 20.);
+    assert_eq!(d4 * d5, Dnum::<2>::new(10., 40.));
+}
+
+fn choose(n: usize, k: usize) -> usize {
+    assert!(k <= n);
+    let mut res = 1;
+    for i in 0..k {
+        res *= n - i
+    }
+    for i in 1..=k {
+        res /= i;
+    }
+    res
+}
+
+#[test]
+fn test_choose() {
+    assert_eq!(choose(0, 0), 1);
+    assert_eq!(choose(0, 0), 1);
+    assert_eq!(choose(1, 1), 1);
+    assert_eq!(choose(2, 1), 2);
+    assert_eq!(choose(2, 2), 1);
+    assert_eq!(choose(3, 0), 1);
+    assert_eq!(choose(3, 1), 3);
+    assert_eq!(choose(3, 2), 3);
+    assert_eq!(choose(3, 3), 1);
+}

--- a/src/dvec.rs
+++ b/src/dvec.rs
@@ -116,8 +116,8 @@ impl std::fmt::Display for Dvec {
     }
 }
 
-impl std::ops::Index<usize> for Dvec {
-    type Output = f64;
+impl<T: Tensor> std::ops::Index<usize> for Dvec<T> {
+    type Output = T;
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }

--- a/src/dvec.rs
+++ b/src/dvec.rs
@@ -1,0 +1,164 @@
+use std::collections::VecDeque;
+
+#[derive(Clone, PartialEq, Debug)]
+/// A dynamic dual number of arbitrary order, translated from C++ in a paper [^1]
+///
+/// [^1]: Higher Order Automatic Differentiation with Dual Numbers (doi: https://doi.org/10.3311/PPee.16341)
+pub struct Dvec(VecDeque<f64>);
+
+impl Dvec {
+    pub fn new_n(v: f64, d: f64, n: usize) -> Self {
+        let mut f = VecDeque::new();
+        f.resize(n + 1, 0.);
+        f[0] = v;
+        if n >= 1 {
+            f[1] = d
+        };
+        Self(f)
+    }
+
+    fn new(v: f64, mut d: Dvec) -> Self {
+        d.0.push_front(v);
+        d
+    }
+
+    pub fn is_real(&self) -> bool {
+        self.0.len() == 1
+    }
+
+    fn F(&self) -> Dvec {
+        // Front operator
+        let mut ffront = self.clone();
+        ffront.0.pop_back();
+        ffront
+    }
+
+    fn D(&self) -> Dvec {
+        // Derivation operator
+        let mut fback = self.clone();
+        fback.0.pop_front();
+        fback
+    }
+
+    pub fn cos(&self) -> Self {
+        if self.is_real() {
+            single(self.0[0].cos())
+        } else {
+            Self::new(self.0[0].cos(), &-&(&self.F()).sin() * &self.D())
+        }
+    }
+
+    pub fn sin(&self) -> Self {
+        if self.is_real() {
+            single(self.0[0].sin())
+        } else {
+            Self::new(self.0[0].sin(), &(&self.F()).cos() * &self.D())
+        }
+    }
+
+    pub fn exp(&self) -> Self {
+        if self.is_real() {
+            single(self.0[0].exp())
+        } else {
+            Self::new(self.0[0].exp(), &(&self.F()).exp() * &self.D())
+        }
+    }
+}
+
+fn single(e: f64) -> Dvec {
+    Dvec::new_n(e, 0., 0)
+}
+
+impl std::fmt::Display for Dvec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for v in &self.0 {
+            write!(f, "{}, ", v)?;
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
+}
+
+impl std::ops::Index<usize> for Dvec {
+    type Output = f64;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::Add for &Dvec {
+    type Output = Dvec;
+    fn add(self, rhs: &Dvec) -> Self::Output {
+        if self.is_real() || rhs.is_real() {
+            single(self.0[0] + rhs.0[0])
+        } else {
+            Dvec::new(self.0[0] + rhs.0[0], &self.D() + &rhs.D())
+        }
+    }
+}
+
+impl std::ops::Sub for &Dvec {
+    type Output = Dvec;
+    fn sub(self, rhs: &Dvec) -> Self::Output {
+        if self.is_real() || rhs.is_real() {
+            single(self.0[0] - rhs.0[0])
+        } else {
+            Dvec::new(self.0[0] - rhs.0[0], &self.D() - &rhs.D())
+        }
+    }
+}
+
+impl std::ops::Mul for &Dvec {
+    type Output = Dvec;
+    fn mul(self, rhs: &Dvec) -> Self::Output {
+        if self.is_real() || rhs.is_real() {
+            single(self.0[0] * rhs.0[0])
+        } else {
+            Dvec::new(
+                self.0[0] * rhs.0[0],
+                &(&self.D() * &rhs.F()) + &(&self.F() * &rhs.D()),
+            )
+        }
+    }
+}
+
+impl std::ops::Div for Dvec {
+    type Output = Self;
+    fn div(self, rhs: Dvec) -> Dvec {
+        if self.is_real() || rhs.is_real() {
+            single(self.0[0] / rhs.0[0])
+        } else {
+            Dvec::new(
+                self.0[0] / rhs.0[0],
+                (&(&self.D() * &rhs) - &(&self * &rhs.D())) / (&rhs * &rhs),
+            )
+        }
+    }
+}
+
+impl std::ops::Neg for &Dvec {
+    type Output = Dvec;
+    fn neg(self) -> Self::Output {
+        let mut ret = self.clone();
+        ret.0.iter_mut().for_each(|v| *v = -*v);
+        ret
+    }
+}
+
+#[test]
+fn test_dvec() {
+    let d1 = Dvec::new_n(0., 1., 1);
+    assert_eq!(d1.D(), Dvec::new_n(1., 0., 0));
+    let d2 = Dvec::new_n(2., 0., 0);
+    let d3 = &d1 + &d2;
+    assert_eq!(d3, Dvec::new_n(2., 0., 0));
+    assert_eq!(&d1 * &d2, Dvec::new_n(0., 0., 0));
+    let d4 = Dvec::new_n(0.5, 0., 0);
+    assert_eq!(d3 / d4, Dvec::new_n(4., 0., 0));
+    let d5 = Dvec::new_n(2., 0., 1);
+    assert_eq!(&d1 * &d5, Dvec::new_n(0., 2., 1));
+    let d6 = d1.sin();
+    assert_eq!(d6, Dvec::new_n(0., 1., 1));
+    assert_eq!(d1.cos(), Dvec::new_n(1., 0., 1));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
+mod dnum;
+mod dvec;
 pub mod error;
 mod rc_term;
 mod tape;
 mod tensor;
 mod term;
-mod dnum;
 
 pub use dnum::Dnum;
+pub use dvec::Dvec;
 pub use rc_term::{RcDotBuilder, RcTerm};
 pub use tape::{Tape, TapeTerm};
 pub use tensor::Tensor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@ mod rc_term;
 mod tape;
 mod tensor;
 mod term;
+mod dnum;
 
+pub use dnum::Dnum;
 pub use rc_term::{RcDotBuilder, RcTerm};
 pub use tape::{Tape, TapeTerm};
 pub use tensor::Tensor;


### PR DESCRIPTION
Fixes #4 

We introduce a new type, called `Dvec`, to the library.
It is direct translation from C++ in the paper [Higher Order Automatic Differentiation with Dual Numbers](https://pp.bme.hu/eecs/article/download/16341/8918/87511).

```rust
use rustograd::Dvec;

let mut f = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
writeln!(
    f,
    "x, exp(-x^2), d exp(-x^2)/dx, d^2 exp(-x^2)/dx^2, d^3 exp(-x^2)/dx^3"
)
.unwrap();
for i in -40..40 {
    let x = i as f64 / 10.;
    // Calculate up to 3rd order differentials
    let d1 = Dvec::new_n(x, 1., 3);
    let d2 = &d1 * &d1;
    let d3 = -&d2;
    let d4 = d3.apply(|x, _| x.exp());
    let res = d4;
    writeln!(f, "{x}, {}, {}, {}, {}", res[0], res[1], res[2], res[3]).unwrap();
}
```

Unfortunately it is only forward mode, and not compatible with `RcTerm` or `TapeTerm`, but they can be used as an independent type to compute arbitrary order (ordinary) derivatives.

There is another significant differences between our new type, `Dvec`, and existing ones, `RcTerm` and `TapeTerm`. `Dvec` is dynamic, in other words, define-by-run design, while `*Term` is define-and-run, or static.

However, it is generic over the contained type as long as the type implements `Tensor`, so it can be vectorized.

We won't be able to find a good way to merge them into one type (or if it's even possible or make sense), so for now we provide with them as separate types.

Also, cross-variable differentiations (such as $\frac{\partial^2}{\partial x\partial y}$) are not supported yet.