### PR TITLE
 Value transformation operators in RcTerm and TapeTerm

### DIFF
--- a/examples/rc_tensor_curve_fit.rs
+++ b/examples/rc_tensor_curve_fit.rs
@@ -1,6 +1,6 @@
 //! Least squares fitting to a Gaussian distribution using gradient descent.
 
-use rustograd::{RcTerm, Tensor};
+use rustograd::{RcTerm, Tensor, UnaryFn};
 
 use std::{fmt::Display, io::Write, ops::Range};
 
@@ -8,42 +8,34 @@ use std::{fmt::Display, io::Write, ops::Range};
 struct MyTensor(Vec<f64>);
 
 impl MyTensor {
+    fn sum(self) -> Self {
+        MyTensor(vec![self.0.iter().sum()])
+    }
+
     fn exp(self) -> Self {
         Self(self.0.into_iter().map(f64::exp).collect())
     }
 }
 
-fn broadcast_binop(lhs: MyTensor, rhs: MyTensor, op: impl Fn(f64, f64) -> f64) -> MyTensor {
-    // Broadcasting rules
-    MyTensor(if lhs.0.len() == 1 {
-        let lhs = lhs.0[0];
-        rhs.0.into_iter().map(|rhs| op(lhs, rhs)).collect()
-    } else if rhs.0.len() == 1 {
-        let rhs = rhs.0[0];
-        lhs.0.into_iter().map(|lhs| op(lhs, rhs)).collect()
-    } else {
+const XRANGE: Range<i32> = -40..40;
+
+fn tensor_binop(lhs: MyTensor, rhs: MyTensor, op: impl Fn(f64, f64) -> f64) -> MyTensor {
+    assert_eq!(lhs.0.len(), rhs.0.len());
+    MyTensor(
         lhs.0
             .into_iter()
             .zip(rhs.0.into_iter())
             .map(|(lhs, rhs)| op(lhs, rhs))
-            .collect()
-    })
+            .collect(),
+    )
 }
 
-fn broadcast_binassign(lhs: &mut MyTensor, rhs: MyTensor, op: impl Fn(f64, f64) -> f64) {
-    // Broadcasting rules
-    if lhs.0.len() == 1 {
-        let lhs_val = lhs.0[0];
-        lhs.0 = rhs.0.into_iter().map(|rhs| op(lhs_val, rhs)).collect();
-    } else if rhs.0.len() == 1 {
-        let rhs = rhs.0[0];
-        lhs.0.iter_mut().for_each(|lhs| *lhs = op(*lhs, rhs));
-    } else {
-        lhs.0
-            .iter_mut()
-            .zip(rhs.0.into_iter())
-            .for_each(|(lhs, rhs)| *lhs = op(*lhs, rhs));
-    }
+fn tensor_binassign(lhs: &mut MyTensor, rhs: MyTensor, op: impl Fn(f64, f64) -> f64) {
+    assert_eq!(lhs.0.len(), rhs.0.len());
+    lhs.0
+        .iter_mut()
+        .zip(rhs.0.into_iter())
+        .for_each(|(lhs, rhs)| *lhs = op(*lhs, rhs));
 }
 
 impl Display for MyTensor {
@@ -51,6 +43,7 @@ impl Display for MyTensor {
         for item in &self.0 {
             write!(f, "{item}, ")?;
         }
+        // write!(f, "[{}]", self.0.len())?;
         Ok(())
     }
 }
@@ -64,33 +57,33 @@ impl Default for MyTensor {
 impl std::ops::Add for MyTensor {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
-        broadcast_binop(self, rhs, f64::add)
+        tensor_binop(self, rhs, f64::add)
     }
 }
 
 impl std::ops::AddAssign for MyTensor {
     fn add_assign(&mut self, rhs: Self) {
-        broadcast_binassign(self, rhs, |lhs, rhs| lhs + rhs);
+        tensor_binassign(self, rhs, |lhs, rhs| lhs + rhs);
     }
 }
 
 impl std::ops::Sub for MyTensor {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
-        broadcast_binop(self, rhs, f64::sub)
+        tensor_binop(self, rhs, f64::sub)
     }
 }
 
 impl std::ops::SubAssign for MyTensor {
     fn sub_assign(&mut self, rhs: Self) {
-        broadcast_binassign(self, rhs, |lhs, rhs| lhs - rhs);
+        tensor_binassign(self, rhs, |lhs, rhs| lhs - rhs);
     }
 }
 
 impl std::ops::Mul for MyTensor {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self::Output {
-        broadcast_binop(self, rhs, f64::mul)
+        tensor_binop(self, rhs, f64::mul)
     }
 }
 
@@ -105,7 +98,7 @@ impl std::ops::Mul<f64> for MyTensor {
 impl std::ops::Div for MyTensor {
     type Output = Self;
     fn div(self, rhs: Self) -> Self::Output {
-        broadcast_binop(self, rhs, f64::div)
+        tensor_binop(self, rhs, f64::div)
     }
 }
 
@@ -133,7 +126,7 @@ fn main() {
         0.75 * (-(x - 1.2).powf(2.) / 0.35).exp()
     }
 
-    let samples: Vec<_> = (-40..40).map(|i| i as f64 / 10.).collect();
+    let samples: Vec<_> = XRANGE.map(|i| i as f64 / 10.).collect();
     let truth_data: Vec<_> = samples.iter().map(|x| truth(*x)).collect();
 
     let calc_loss = || {
@@ -150,15 +143,13 @@ fn main() {
         model.mu.set(MyTensor(vec![*mu])).unwrap();
         model.sigma.set(MyTensor(vec![*sigma])).unwrap();
         model.scale.set(MyTensor(vec![*scale])).unwrap();
-        // for (&xval, &sample_y) in samples.iter().zip(truth_data.iter()) {
         model.x.set(MyTensor(samples.clone())).unwrap();
         model.sample_y.set(MyTensor(truth_data.clone())).unwrap();
         model.loss.eval();
         model.loss.backprop().unwrap();
-        *mu -= RATE * model.mu.grad().0.iter().sum::<f64>();
-        *sigma -= RATE * model.sigma.grad().0.iter().sum::<f64>();
-        *scale -= RATE * model.scale.grad().0.iter().sum::<f64>();
-        // }
+        *mu -= RATE * model.mu.grad().0[0];
+        *sigma -= RATE * model.sigma.grad().0[0];
+        *scale -= RATE * model.scale.grad().0[0];
     };
 
     let mut mu_val = INIT_MU;
@@ -217,21 +208,23 @@ fn main() {
         model
             .loss
             .dot_builder()
+            .vertical(true)
             .show_values(false)
             .dot(&mut file)
             .unwrap();
         counter.set(i + 1);
     };
 
-    model.x.set(MyTensor(vec![0.])).unwrap();
     model.loss.clear();
     model.loss.clear_grad();
+    model.x.set(MyTensor(samples)).unwrap();
     model.loss.eval_cb(&callback);
     model.loss.backprop_cb(&callback).unwrap();
     let mut dotfile = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
     model
         .loss
         .dot_builder()
+        .vertical(true)
         .show_values(false)
         .dot(&mut dotfile)
         .unwrap();
@@ -247,22 +240,78 @@ struct Model {
     loss: RcTerm<MyTensor>,
 }
 
+fn bcast(v: MyTensor) -> MyTensor {
+    // println!("Broadcasting {} to {}", v.0[0], XRANGE.len());
+    MyTensor(XRANGE.map(|_| v.0[0]).collect())
+}
+
+fn bcast1(_: MyTensor) -> MyTensor {
+    // println!("Broadcasting {} to {}", v.0[0], XRANGE.len());
+    MyTensor(vec![1.; XRANGE.len()])
+}
+
+fn distribute(v: MyTensor) -> MyTensor {
+    // println!("Ditributing {} to {}", v.0[0], XRANGE.len());
+    MyTensor(XRANGE.map(|_| v.0[0] / XRANGE.len() as f64).collect())
+}
+
+fn collapse(v: MyTensor) -> MyTensor {
+    // println!("Broadcasting {} to {}", v.0[0], XRANGE.len());
+    MyTensor(vec![v.0.len() as f64])
+}
+
+struct Broadcaster;
+
+impl UnaryFn<MyTensor> for Broadcaster {
+    fn name(&self) -> String {
+        "bcast".to_string()
+    }
+    fn f(&self, data: MyTensor) -> MyTensor {
+        bcast(data)
+    }
+    fn grad(&self, data: MyTensor) -> MyTensor {
+        bcast1(data)
+    }
+    fn t(&self, data: MyTensor) -> MyTensor {
+        MyTensor::sum(data)
+    }
+}
+
+struct Summer;
+
+impl UnaryFn<MyTensor> for Summer {
+    fn name(&self) -> String {
+        "sum".to_string()
+    }
+    fn f(&self, data: MyTensor) -> MyTensor {
+        MyTensor::sum(data)
+    }
+    fn grad(&self, data: MyTensor) -> MyTensor {
+        collapse(data)
+    }
+    fn t(&self, data: MyTensor) -> MyTensor {
+        distribute(data)
+    }
+}
+
 fn build_model() -> Model {
     let zeros = MyTensor::default();
 
     let x = RcTerm::new("x", zeros.clone());
     let mu = RcTerm::new("mu", zeros.clone());
+    let v_mu = mu.apply_t(Box::new(Broadcaster));
     let sigma = RcTerm::new("sigma", MyTensor::one());
+    let sigma2 = &sigma * &sigma;
+    let v_sigma2 = sigma2.apply_t(Box::new(Broadcaster));
     let scale = RcTerm::new("scale", MyTensor::one());
-    let x_mu = &x - &mu;
+    let v_scale = scale.apply_t(Box::new(Broadcaster));
+    let x_mu = &x - &v_mu;
     let x_mu2 = &x_mu * &x_mu;
-    let x_mu2_sigma = &x_mu2 / &sigma;
-    let pre_exp = &x_mu2_sigma / &sigma;
-    let neg_pre_exp = -&pre_exp;
-    let gaussian = &scale * &neg_pre_exp.apply("exp", MyTensor::exp, MyTensor::exp);
+    let pre_exp = -&(&x_mu2 / &v_sigma2);
+    let gaussian = &v_scale * &pre_exp.apply("exp", MyTensor::exp, MyTensor::exp);
     let sample_y = RcTerm::new("y", zeros.clone());
     let diff = &gaussian - &sample_y;
-    let loss = &diff * &diff;
+    let loss = (&diff * &diff).apply_t(Box::new(Summer));
 
     Model {
         x,

--- a/examples/tape_peak_separation.rs
+++ b/examples/tape_peak_separation.rs
@@ -132,7 +132,9 @@ fn main() {
         let i = counter.get();
         let mut file =
             std::io::BufWriter::new(std::fs::File::create(format!("dot{i}.dot")).unwrap());
-        model.loss.dot_builder()
+        model
+            .loss
+            .dot_builder()
             .show_values(false)
             .vertical(true)
             .highlights(idx)
@@ -145,7 +147,12 @@ fn main() {
     model.loss.eval_cb(&callback);
     model.loss.backprop_cb(&callback).unwrap();
     let mut dotfile = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
-    model.loss.dot_builder().vertical(true).dot(&mut dotfile).unwrap();
+    model
+        .loss
+        .dot_builder()
+        .vertical(true)
+        .dot(&mut dotfile)
+        .unwrap();
 }
 
 struct Model<'a> {

--- a/examples/tape_tensor_curve_fit.rs
+++ b/examples/tape_tensor_curve_fit.rs
@@ -1,6 +1,6 @@
 //! Least squares fitting to a Gaussian distribution using gradient descent.
 
-use rustograd::{Tape, TapeFn, TapeTerm, Tensor};
+use rustograd::{Tape, TapeTerm, Tensor, UnaryFn};
 
 use std::{fmt::Display, io::Write, ops::Range};
 
@@ -268,7 +268,7 @@ fn collapse(v: MyTensor) -> MyTensor {
 
 struct Broadcaster;
 
-impl TapeFn<MyTensor> for Broadcaster {
+impl UnaryFn<MyTensor> for Broadcaster {
     fn name(&self) -> String {
         "bcast".to_string()
     }
@@ -285,7 +285,7 @@ impl TapeFn<MyTensor> for Broadcaster {
 
 struct Summer;
 
-impl TapeFn<MyTensor> for Summer {
+impl UnaryFn<MyTensor> for Summer {
     fn name(&self) -> String {
         "sum".to_string()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,13 @@ mod rc_term;
 mod tape;
 mod tensor;
 mod term;
+mod unary_fn;
 
 pub use dnum::Dnum;
 pub use dvec::Dvec;
 pub use rc_term::{RcDotBuilder, RcTerm};
-pub use tape::{Tape, TapeFn, TapeTerm};
+pub use tape::{Tape, TapeTerm};
 pub use tensor::Tensor;
 #[allow(deprecated)]
 pub use term::Term;
+pub use unary_fn::UnaryFn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod term;
 pub use dnum::Dnum;
 pub use dvec::Dvec;
 pub use rc_term::{RcDotBuilder, RcTerm};
-pub use tape::{Tape, TapeTerm};
+pub use tape::{Tape, TapeFn, TapeTerm};
 pub use tensor::Tensor;
 #[allow(deprecated)]
 pub use term::Term;

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -48,7 +48,6 @@ struct PtrTapeFn<T> {
     name: String,
     f: fn(T) -> T,
     grad: fn(T) -> T,
-    t: Option<fn(T) -> T>,
 }
 
 impl<T> TapeFn<T> for PtrTapeFn<T> {
@@ -62,11 +61,7 @@ impl<T> TapeFn<T> for PtrTapeFn<T> {
         (self.grad)(data)
     }
     fn t(&self, data: T) -> T {
-        if let Some(t) = self.t {
-            t(data)
-        } else {
-            data
-        }
+        data
     }
 }
 
@@ -272,7 +267,6 @@ impl<'a, T: Tensor + 'static> TapeTerm<'a, T> {
                     name: self_name,
                     f,
                     grad,
-                    t: None,
                 }),
             }),
         )

--- a/src/unary_fn.rs
+++ b/src/unary_fn.rs
@@ -1,0 +1,30 @@
+/// A trait that represents an unary operation on a value.
+/// It needs to implement a transformation of the value, the gradient
+/// and its reverse transformation (transposition).
+pub trait UnaryFn<T> {
+    fn name(&self) -> String;
+    fn f(&self, data: T) -> T;
+    fn grad(&self, data: T) -> T;
+    fn t(&self, data: T) -> T;
+}
+
+pub(crate) struct PtrUnaryFn<T> {
+    pub name: String,
+    pub f: fn(T) -> T,
+    pub grad: fn(T) -> T,
+}
+
+impl<T> UnaryFn<T> for PtrUnaryFn<T> {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+    fn f(&self, data: T) -> T {
+        (self.f)(data)
+    }
+    fn grad(&self, data: T) -> T {
+        (self.grad)(data)
+    }
+    fn t(&self, data: T) -> T {
+        data
+    }
+}


### PR DESCRIPTION
# The problem

We have generic value type support, so that you can run AD in tensor types. However, there is one problem.
Sometimes we want to have a parameter that applies to all the elements in a function. For example, in a Gaussian distribution, we can take a vector of $\mathbf{x}$ s (note that boldface $\mathbf{x}$ indicates a vector), but the parameters $\mu, \sigma, s$ are not really vectors (indicated by non-bold italics).

$$
f(\mathbf{x}; \mu, \sigma, s) = s \exp\left( -\frac{ (\mathbf{x} - \mu)^2 }{\sigma^2} \right)
$$

In other words, we have an expression that mixes scalars and vectors (or in general tensors).

Before this PR, we have used broadcasting rules like numpy to forcefully match the shape of vectors that are operated.
For example,

```rust
let a = MyTensor(vec![0., 1., 2.]);
let b = MyTensor(vec![1.]);
assert_eq!(a + b, MyTensor(vec![1., 2., 3.]);
```

While this is convenient, it makes tracking gradient really hard, because you lose the information of original vector shapes after the operation.
We need to track back the expression tree in reverse and apply gradient information accordingly. The vector shape information is really important for that.

# The solution

It means we need to preserve the vector shapes in each operation, so the broadcasting rule cannot be applied.
We can use UnaryFn to implement transformation of vector shapes. For example, summing a vector's elements can be an operation like below.

```rust
impl MyTensor {
    fn sum(self) -> Self {
        MyTensor(vec![self.0.iter().sum()])
    }
}
```

We also need to supply with the transformation for the gradient.
Now this is a tricky part. Although the transformation of sum can be implemented by just summing all the elements, its gradient is not.

$$
\begin{align*}
f(x) &= \sum_i g_i(x) \\
\frac{d f}{dx} &= \sum_i \frac{df}{dg_i} \frac{dg_i}{dx}
\end{align*}
$$

What we need for the gradient function is to just count the size of the vector and make it a local gradient value.
Remember, this node's sole purpose is to change the shape of the vector, so the elements themselves go through identity function. So we need what we call `collapse` function.

```rust
fn collapse(v: MyTensor) -> MyTensor {
    MyTensor(vec![v.0.len() as f64])
}
```

The last puzzle is the _transposition_. When we track back in the expression tree, we need to apply inverse of the change of the shape. So, if the node is a `sum`, the inverse needs to transform a scalar back to the vector of many elements.

I used the word _inverse_, but it is technically not correct, because it is not an inverse in the matrix multiplication sense.
We need to transform the gradient in the compatible shape with the input value.

It turned out, this operation requires dividing the value by the size of the vector and make a uniform vector with that value.
This operation is what we call `distribute`.

```rust
fn distribute(v: MyTensor) -> MyTensor {
    MyTensor(XRANGE.map(|_| v.0[0] / XRANGE.len() as f64).collect())
}
```

We need to apply this transformation before passing it to the parent node.

```rust
                let val = value(nodes, term)?;
                let newgrad = grad * collapse(val);
                let endgrad = distribute(newgrad);
                backprop_set(nodes, term, endgrad, callback)
```

This is new, because we assumed that the product of local gradient and backpropped gradient has the same shape as the parent gradient.
In order to model this, we need not only `f` and `grad` functions in a UnaryFn node, but also a "backward transposition" function (in `sum` operation's case, it is `distribute`).

This is getting quite complicated to manage 3 functions in a node, and we want something generic over scalar and tensor values, so we make a new trait `TapeFn`, which has 4 methods:

```rust
pub trait TapeFn<T> {
    fn name(&self) -> String;
    fn f(&self, data: T) -> T;
    fn grad(&self, data: T) -> T;
    fn t(&self, data: T) -> T;
}
```

* `name` is just a convenience method for visualization.
* `f` is the same as the old function pointer, transforming the value from input to output.
* `grad` is similar to `f`, but it applies transformation to the local differentiation, from input to output.
* `t` is the new guy, making transposition of a gradient, from output to input.

`UnaryFnPayload` has an owned pointer to the trait object now.

```rust
struct UnaryFnPayload<T> {
    term: u32,
    f: Box<dyn TapeFn<T>>,
}
```

Now, we provide with a default implementation of `TapeFn` called `PtrTapeFn` with function pointers to keep compatibility.
Note that `t` is an identity function because you don't need to change shape in scalar types (and functions that don't change shape).

```rust
struct PtrTapeFn<T> {
    name: String,
    f: fn(T) -> T,
    grad: fn(T) -> T,
}

impl<T> TapeFn<T> for PtrTapeFn<T> {
    fn name(&self) -> String {
        self.name.clone()
    }
    fn f(&self, data: T) -> T {
        (self.f)(data)
    }
    fn grad(&self, data: T) -> T {
        (self.grad)(data)
    }
    fn t(&self, data: T) -> T {
        data
    }
}
```

Now our `TapeTerm::apply` method constructs this default implementation and works like before.

```rust
impl<T: Tensor> TapeTerm<T> {
    pub fn apply(
        &self,
        name: &(impl AsRef<str> + ?Sized),
        f: fn(T) -> T,
        grad: fn(T) -> T,
    ) -> Self {
        let self_name = self.tape.nodes.borrow()[self.idx as usize].name.clone();
        let name = format!("{}({})", name.as_ref(), self_name);
        self.tape.term_name(
            name,
            TapeValue::UnaryFn(UnaryFnPayload {
                term: self.idx,
                f: Box::new(PtrTapeFn {
                    name: self_name,
                    f,
                    grad,
                }),
            }),
        )
    }
}
```

But we also expose the method to set a custom implementation.

```rust
impl<T: Tensor> TapeTerm<T> {
    /// Apply a function, its derivative and a transposition
    pub fn apply_t(&self, f: Box<dyn TapeFn<T>>) -> Self {
        let self_name = self.tape.nodes.borrow()[self.idx as usize].name.clone();
        let name = format!("{}({})", f.name(), self_name);
        self.tape.term_name(
            name,
            TapeValue::UnaryFn(UnaryFnPayload { term: self.idx, f }),
        )
    }
}
```

The user can implement `TapeFn` trait to their own types. For example, this is the implementation of the sum operator:

```rust
struct Summer;

impl TapeFn<MyTensor> for Summer {
    fn name(&self) -> String {
        "sum".to_string()
    }
    fn f(&self, data: MyTensor) -> MyTensor {
        MyTensor::sum(data)
    }
    fn grad(&self, data: MyTensor) -> MyTensor {
        collapse(data)
    }
    fn t(&self, data: MyTensor) -> MyTensor {
        distribute(data)
    }
}
```

and this is the broadcasting operator:

```rust
struct Broadcaster;

impl TapeFn<MyTensor> for Broadcaster {
    fn name(&self) -> String {
        "bcast".to_string()
    }
    fn f(&self, data: MyTensor) -> MyTensor {
        bcast(data)
    }
    fn grad(&self, data: MyTensor) -> MyTensor {
        bcast1(data)
    }
    fn t(&self, data: MyTensor) -> MyTensor {
        MyTensor::sum(data)
    }
}
```

with these types, the user can construct an operation that transforms a scalar to a vector:

```rust
    let mu = tape.term("mu", MyTensor::default());
    let v_mu = mu.apply_t(Box::new(Broadcaster));
```

and vise versa.

```rust
let loss = (diff * diff).apply_t(Box::new(Summer));
```

Please see an example implementation in examples/tape_tensor_curve_fit.rs for the full implementation.

We can verify the shape transformation by a graph visualization.

![graphviz (5)](https://github.com/msakuta/rustograd/assets/2798715/df6f43a1-de77-476b-b566-5f7a45c6d7fd)

And the optimization works just like before.

![curve_fit](https://github.com/msakuta/rustograd/assets/2798715/2020e922-1a7f-4704-a4c9-909e89e485b1)

We can implement the same way in `RcTerm`.

```rust
    let mu = RcTerm::new("mu", zeros.clone());
    let v_mu = mu.apply_t(Box::new(Broadcaster));
```

See examples/rc_tensor_curve_fit.rs for the full example.

Also we gain a little bit of performance because calculations can be done in scalars.
In the plot below, `rc_t` is the new implementation for `RcTerm` with scalars, `rc_bcast` is the new implementation with the tensor, `tape_t` is the new implementation of `TapeTerm` with a scalar, and `tape_bcast` is the implementation with the tensor.

![term_perf](https://github.com/msakuta/rustograd/assets/2798715/a3477b51-036d-488d-bb11-995870aa3e01)

As expected, tensors with broadcasting and sum operators are more optimal, because they have less redundant computation, but interestingly, `rc_bcast` is faster than `tape_bcast`. I don't know why.
