### PR TITLE
Generate derived graph from existing one

### DIFF
--- a/examples/tape_gen_graph.rs
+++ b/examples/tape_gen_graph.rs
@@ -1,0 +1,19 @@
+use rustograd::Tape;
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 123.);
+    let b = tape.term("b", 321.);
+    let aba = a - b + a;
+    let daba = aba.gen_graph(&a).unwrap();
+    aba.eval();
+    aba.backprop().unwrap();
+    daba.eval_noclear();
+
+    assert!(daba.gen_graph(&a).is_none());
+
+    daba.dot_builder()
+        .show_values(true)
+        .dot(&mut std::io::stdout())
+        .unwrap();
+}

--- a/examples/tape_gen_graph_div.rs
+++ b/examples/tape_gen_graph_div.rs
@@ -1,0 +1,17 @@
+use rustograd::Tape;
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let b = tape.term("b", 3.21);
+    let abb = (a + b) / b;
+    let dabb = abb.gen_graph(&b).unwrap();
+    abb.eval();
+    abb.backprop().unwrap();
+    dabb.eval_noclear();
+
+    dabb.dot_builder()
+        .show_values(true)
+        .dot(&mut std::io::stdout())
+        .unwrap();
+}

--- a/examples/tape_gen_graph_fn.rs
+++ b/examples/tape_gen_graph_fn.rs
@@ -1,5 +1,5 @@
 use rustograd::{
-    tape::{add_mul, TapeNode},
+    tape::{add_mul, TapeIndex, TapeNode},
     Tape, UnaryFn,
 };
 
@@ -21,11 +21,11 @@ impl UnaryFn<f64> for ExpFn {
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        idx: u32,
-        _input: u32,
-        derived: u32,
-    ) -> Option<u32> {
-        Some(add_mul(nodes, idx, derived))
+        _input: TapeIndex,
+        output: TapeIndex,
+        derived: TapeIndex,
+    ) -> Option<TapeIndex> {
+        Some(add_mul(nodes, output, derived))
     }
 }
 

--- a/examples/tape_gen_graph_fn.rs
+++ b/examples/tape_gen_graph_fn.rs
@@ -1,0 +1,47 @@
+use rustograd::{
+    tape::{add_mul, TapeNode},
+    Tape, UnaryFn,
+};
+
+struct ExpFn;
+
+impl UnaryFn<f64> for ExpFn {
+    fn name(&self) -> String {
+        "exp".to_string()
+    }
+
+    fn f(&self, data: f64) -> f64 {
+        data.exp()
+    }
+
+    fn grad(&self, data: f64) -> f64 {
+        data.exp()
+    }
+
+    fn gen_graph(
+        &self,
+        nodes: &mut Vec<TapeNode<f64>>,
+        idx: u32,
+        _input: u32,
+        derived: u32,
+    ) -> Option<u32> {
+        Some(add_mul(nodes, idx, derived))
+    }
+}
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let b = tape.term("b", 3.21);
+    let exp_a = (a * b).apply_t(Box::new(ExpFn));
+    let d_exp_a = exp_a.gen_graph(&a).unwrap();
+    exp_a.eval();
+    exp_a.backprop().unwrap();
+    d_exp_a.eval_noclear();
+
+    d_exp_a
+        .dot_builder()
+        .show_values(true)
+        .dot(&mut std::io::stdout())
+        .unwrap();
+}

--- a/examples/tape_gen_graph_gaussian.rs
+++ b/examples/tape_gen_graph_gaussian.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use rustograd::{
-    tape::{add_mul, TapeNode},
+    tape::{add_mul, TapeIndex, TapeNode},
     Tape, UnaryFn,
 };
 
@@ -23,11 +23,11 @@ impl UnaryFn<f64> for ExpFn {
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        idx: u32,
-        _input: u32,
-        derived: u32,
-    ) -> Option<u32> {
-        Some(add_mul(nodes, idx, derived))
+        _input: TapeIndex,
+        output: TapeIndex,
+        derived: TapeIndex,
+    ) -> Option<TapeIndex> {
+        Some(add_mul(nodes, output, derived))
     }
 }
 

--- a/examples/tape_gen_graph_gaussian.rs
+++ b/examples/tape_gen_graph_gaussian.rs
@@ -62,6 +62,7 @@ fn main() {
         .last()
         .unwrap()
         .dot_builder()
+        .vertical(true)
         .show_values(true)
         .dot(&mut writer)
         .unwrap();

--- a/examples/tape_gen_graph_gaussian.rs
+++ b/examples/tape_gen_graph_gaussian.rs
@@ -63,7 +63,7 @@ fn main() {
         .unwrap()
         .dot_builder()
         .vertical(true)
-        .show_values(true)
+        .show_values(false)
         .dot(&mut writer)
         .unwrap();
 }

--- a/examples/tape_gen_graph_gaussian.rs
+++ b/examples/tape_gen_graph_gaussian.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+
+use rustograd::{
+    tape::{add_mul, TapeNode},
+    Tape, UnaryFn,
+};
+
+struct ExpFn;
+
+impl UnaryFn<f64> for ExpFn {
+    fn name(&self) -> String {
+        "exp".to_string()
+    }
+
+    fn f(&self, data: f64) -> f64 {
+        data.exp()
+    }
+
+    fn grad(&self, data: f64) -> f64 {
+        data.exp()
+    }
+
+    fn gen_graph(
+        &self,
+        nodes: &mut Vec<TapeNode<f64>>,
+        idx: u32,
+        _input: u32,
+        derived: u32,
+    ) -> Option<u32> {
+        Some(add_mul(nodes, idx, derived))
+    }
+}
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let exp_a = (-a * a).apply_t(Box::new(ExpFn));
+
+    let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    let mut derivatives = vec![exp_a];
+    let mut next = exp_a;
+    write!(csv, "x, $e^x$, ").unwrap();
+    for i in 1..4 {
+        next = next.gen_graph(&a).unwrap();
+        derivatives.push(next);
+        write!(csv, "$(d^{i} \\exp(-x^2)/(d x^{i})$, ").unwrap();
+    }
+    writeln!(csv, "").unwrap();
+
+    for i in -50..50 {
+        let x = i as f64 * 0.1;
+        a.set(x).unwrap();
+        write!(csv, "{x}, ").unwrap();
+        for d in &derivatives {
+            write!(csv, "{}, ", d.eval()).unwrap();
+        }
+        writeln!(csv, "").unwrap();
+    }
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
+    derivatives
+        .last()
+        .unwrap()
+        .dot_builder()
+        .show_values(true)
+        .dot(&mut writer)
+        .unwrap();
+}

--- a/examples/tape_gen_graph_mixed.rs
+++ b/examples/tape_gen_graph_mixed.rs
@@ -2,17 +2,18 @@ use rustograd::Tape;
 
 fn main() {
     let tape = Tape::new();
-    let a = tape.term("a", 123.);
-    let b = tape.term("b", 321.);
-    let aba = -a + a - b + a;
+    let a = tape.term("a", 2.);
+    let b = tape.term("b", 1.);
+    // let c = tape.term("b", 42.);
+    let aba = (a - b) * a;
     let daba = aba.gen_graph(&a).unwrap();
+    let dabab = daba + b;
     aba.eval();
     aba.backprop().unwrap();
-    daba.eval_noclear();
+    dabab.eval_noclear();
 
-    assert!(daba.gen_graph(&a).is_none());
-
-    daba.dot_builder()
+    dabab
+        .dot_builder()
         .show_values(true)
         .dot(&mut std::io::stdout())
         .unwrap();

--- a/examples/tape_gen_graph_mul.rs
+++ b/examples/tape_gen_graph_mul.rs
@@ -1,0 +1,20 @@
+use rustograd::Tape;
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 123.);
+    let b = tape.term("b", 321.);
+    // let c = tape.term("b", 42.);
+    let aba = (a - b) * a;
+    let daba = aba.gen_graph(&a).unwrap();
+    aba.eval();
+    aba.backprop().unwrap();
+    daba.eval_noclear();
+
+    // assert!(daba.gen_graph(&a).is_none());
+
+    daba.dot_builder()
+        .show_values(true)
+        .dot(&mut std::io::stdout())
+        .unwrap();
+}

--- a/examples/tape_gen_graph_mul.rs
+++ b/examples/tape_gen_graph_mul.rs
@@ -2,8 +2,8 @@ use rustograd::Tape;
 
 fn main() {
     let tape = Tape::new();
-    let a = tape.term("a", 123.);
-    let b = tape.term("b", 321.);
+    let a = tape.term("a", 2.);
+    let b = tape.term("b", 1.);
     // let c = tape.term("b", 42.);
     let aba = (a - b) * a;
     let daba = aba.gen_graph(&a).unwrap();
@@ -11,7 +11,8 @@ fn main() {
     aba.backprop().unwrap();
     daba.eval_noclear();
 
-    // assert!(daba.gen_graph(&a).is_none());
+    let ddaba = daba.gen_graph(&a).unwrap();
+    ddaba.eval_noclear();
 
     daba.dot_builder()
         .show_values(true)

--- a/examples/tape_gen_graph_poly.rs
+++ b/examples/tape_gen_graph_poly.rs
@@ -2,7 +2,7 @@
 use std::io::Write;
 
 use rustograd::{
-    tape::{add_mul, add_unary_fn, add_value, TapeNode},
+    tape::{add_mul, add_unary_fn, add_value, TapeIndex, TapeNode},
     Tape, UnaryFn,
 };
 
@@ -24,10 +24,10 @@ impl UnaryFn<f64> for PolynomialFn {
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        _idx: u32,
-        input: u32,
-        _derived: u32,
-    ) -> Option<u32> {
+        input: TapeIndex,
+        _output: TapeIndex,
+        _derived: TapeIndex,
+    ) -> Option<TapeIndex> {
         if self.0 == 0 {
             None
         } else if 1 < self.0 {

--- a/examples/tape_gen_graph_poly.rs
+++ b/examples/tape_gen_graph_poly.rs
@@ -30,10 +30,16 @@ impl UnaryFn<f64> for PolynomialFn {
     ) -> Option<u32> {
         if self.0 == 0 {
             None
-        } else {
-            let poly = add_unary_fn(nodes, Box::new(Self(self.0 - 1)), input);
+        } else if 1 < self.0 {
+            let poly = if self.0 == 2 {
+                input
+            } else {
+                add_unary_fn(nodes, Box::new(Self(self.0 - 1)), input)
+            };
             let factor = add_value(nodes, self.0 as f64);
             Some(add_mul(nodes, factor, poly))
+        } else {
+            Some(1)
         }
     }
 }
@@ -46,7 +52,7 @@ fn main() {
     let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
     let mut derivatives = vec![sin_a];
     let mut next = sin_a;
-    write!(csv, "x, $x^3)$, ").unwrap();
+    write!(csv, "x, $x^3$, ").unwrap();
     for i in 1..4 {
         let Some(next_i) = next.gen_graph(&a) else { break };
         next = next_i;
@@ -56,7 +62,7 @@ fn main() {
     writeln!(csv, "").unwrap();
 
     for i in -50..50 {
-        let x = i as f64 * 0.1;
+        let x = i as f64 * 0.02;
         a.set(x).unwrap();
         write!(csv, "{x}, ").unwrap();
         for d in &derivatives {

--- a/examples/tape_gen_graph_poly.rs
+++ b/examples/tape_gen_graph_poly.rs
@@ -1,0 +1,76 @@
+//! gen_graph example with polynomials.
+use std::io::Write;
+
+use rustograd::{
+    tape::{add_mul, add_unary_fn, add_value, TapeNode},
+    Tape, UnaryFn,
+};
+
+struct PolynomialFn(i32);
+
+impl UnaryFn<f64> for PolynomialFn {
+    fn name(&self) -> String {
+        format!("(^{})", self.0)
+    }
+
+    fn f(&self, data: f64) -> f64 {
+        data.powi(self.0)
+    }
+
+    fn grad(&self, data: f64) -> f64 {
+        self.0 as f64 * data.powi(self.0 - 1)
+    }
+
+    fn gen_graph(
+        &self,
+        nodes: &mut Vec<TapeNode<f64>>,
+        _idx: u32,
+        input: u32,
+        _derived: u32,
+    ) -> Option<u32> {
+        if self.0 == 0 {
+            None
+        } else {
+            let poly = add_unary_fn(nodes, Box::new(Self(self.0 - 1)), input);
+            let factor = add_value(nodes, self.0 as f64);
+            Some(add_mul(nodes, factor, poly))
+        }
+    }
+}
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let sin_a = (a).apply_t(Box::new(PolynomialFn(3)));
+
+    let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    let mut derivatives = vec![sin_a];
+    let mut next = sin_a;
+    write!(csv, "x, $x^3)$, ").unwrap();
+    for i in 1..4 {
+        let Some(next_i) = next.gen_graph(&a) else { break };
+        next = next_i;
+        derivatives.push(next);
+        write!(csv, "$(d^{i} x^3)/(d x^{i})$, ").unwrap();
+    }
+    writeln!(csv, "").unwrap();
+
+    for i in -50..50 {
+        let x = i as f64 * 0.1;
+        a.set(x).unwrap();
+        write!(csv, "{x}, ").unwrap();
+        for d in &derivatives {
+            write!(csv, "{}, ", d.eval()).unwrap();
+        }
+        writeln!(csv, "").unwrap();
+    }
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
+    derivatives
+        .last()
+        .unwrap()
+        .dot_builder()
+        .show_values(true)
+        .dot(&mut writer)
+        .unwrap();
+}

--- a/examples/tape_gen_graph_sigmoid.rs
+++ b/examples/tape_gen_graph_sigmoid.rs
@@ -65,7 +65,9 @@ fn main() {
         .last()
         .unwrap()
         .dot_builder()
+        .vertical(true)
         .show_values(true)
+        .precision(4)
         .dot(&mut writer)
         .unwrap();
 }

--- a/examples/tape_gen_graph_sigmoid.rs
+++ b/examples/tape_gen_graph_sigmoid.rs
@@ -1,62 +1,52 @@
 use std::io::Write;
 
 use rustograd::{
-    tape::{add_unary_fn, TapeNode},
+    tape::{add_mul, add_sub, add_value, TapeNode},
     Tape, UnaryFn,
 };
 
-struct SinFn(usize);
+struct SigmoidFn;
 
-impl UnaryFn<f64> for SinFn {
+impl UnaryFn<f64> for SigmoidFn {
     fn name(&self) -> String {
-        match self.0 % 4 {
-            0 => "sin",
-            1 => "cos",
-            2 => "-sin",
-            3 => "-cos",
-            _ => unreachable!(),
-        }
-        .to_string()
+        "exp".to_string()
     }
 
     fn f(&self, data: f64) -> f64 {
-        match self.0 % 4 {
-            0 => data.sin(),
-            1 => data.cos(),
-            2 => -data.sin(),
-            3 => -data.cos(),
-            _ => unreachable!(),
-        }
+        1. / (1. + (-data).exp())
     }
 
     fn grad(&self, data: f64) -> f64 {
-        Self(self.0 + 1).f(data)
+        let s = 1. / (1. + (-data).exp());
+        (1. - s) * s
     }
 
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        _idx: u32,
-        input: u32,
+        idx: u32,
+        _input: u32,
         _derived: u32,
     ) -> Option<u32> {
-        Some(add_unary_fn(nodes, Box::new(Self(self.0 + 1)), input))
+        let one = add_value(nodes, 1.);
+        let one_minus_sigmoid = add_sub(nodes, one, idx);
+        Some(add_mul(nodes, one_minus_sigmoid, idx))
     }
 }
 
 fn main() {
     let tape = Tape::new();
     let a = tape.term("a", 1.23);
-    let sin_a = (a).apply_t(Box::new(SinFn(0)));
+    let sin_a = (a).apply_t(Box::new(SigmoidFn));
 
     let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
     let mut derivatives = vec![sin_a];
     let mut next = sin_a;
-    write!(csv, "x, $\\sin(x)$, ").unwrap();
+    write!(csv, "x, $\\mathrm{{sigmoid}}(x)$, ").unwrap();
     for i in 1..4 {
         next = next.gen_graph(&a).unwrap();
         derivatives.push(next);
-        write!(csv, "$(d^{i} \\sin(x)/(d x^{i})$, ").unwrap();
+        write!(csv, "$(d^{i} \\mathrm{{sigmoid}}(x)/(d x^{i})$, ").unwrap();
     }
     writeln!(csv, "").unwrap();
 

--- a/examples/tape_gen_graph_sigmoid.rs
+++ b/examples/tape_gen_graph_sigmoid.rs
@@ -27,8 +27,8 @@ impl UnaryFn<f64> for SigmoidFn {
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        idx: TapeIndex,
         _input: TapeIndex,
+        output: TapeIndex,
         _derived: TapeIndex,
     ) -> Option<TapeIndex> {
         // 1 - sigmoid(x) comes up too often in gen_graph that caching it will remove a lot of
@@ -36,11 +36,11 @@ impl UnaryFn<f64> for SigmoidFn {
         let one_minus_sigmoid = if let Some(cached) = self.node_cache.get() {
             cached
         } else {
-            let cache = add_sub(nodes, TAPE_ONE, idx);
+            let cache = add_sub(nodes, TAPE_ONE, output);
             self.node_cache.set(Some(cache));
             cache
         };
-        Some(add_mul(nodes, one_minus_sigmoid, idx))
+        Some(add_mul(nodes, one_minus_sigmoid, output))
     }
 }
 

--- a/examples/tape_gen_graph_sine.rs
+++ b/examples/tape_gen_graph_sine.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use rustograd::{
-    tape::{add_unary_fn, TapeNode},
+    tape::{add_unary_fn, TapeIndex, TapeNode},
     Tape, UnaryFn,
 };
 
@@ -36,10 +36,10 @@ impl UnaryFn<f64> for SinFn {
     fn gen_graph(
         &self,
         nodes: &mut Vec<TapeNode<f64>>,
-        _idx: u32,
-        input: u32,
-        _derived: u32,
-    ) -> Option<u32> {
+        input: TapeIndex,
+        _output: TapeIndex,
+        _derived: TapeIndex,
+    ) -> Option<TapeIndex> {
         Some(add_unary_fn(nodes, Box::new(Self(self.0 + 1)), input))
     }
 }

--- a/examples/tape_gen_graph_sine.rs
+++ b/examples/tape_gen_graph_sine.rs
@@ -1,0 +1,81 @@
+use std::io::Write;
+
+use rustograd::{
+    tape::{add_unary_fn, TapeNode},
+    Tape, UnaryFn,
+};
+
+struct SinFn(usize);
+
+impl UnaryFn<f64> for SinFn {
+    fn name(&self) -> String {
+        match self.0 % 4 {
+            0 => "sin",
+            1 => "cos",
+            2 => "-sin",
+            3 => "-cos",
+            _ => unreachable!(),
+        }
+        .to_string()
+    }
+
+    fn f(&self, data: f64) -> f64 {
+        match self.0 % 4 {
+            0 => data.sin(),
+            1 => data.cos(),
+            2 => -data.sin(),
+            3 => -data.cos(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn grad(&self, data: f64) -> f64 {
+        Self(self.0 + 1).f(data)
+    }
+
+    fn gen_graph(
+        &self,
+        nodes: &mut Vec<TapeNode<f64>>,
+        _idx: u32,
+        input: u32,
+        _derived: u32,
+    ) -> Option<u32> {
+        Some(add_unary_fn(nodes, Box::new(Self(self.0 + 1)), input))
+    }
+}
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let sin_a = (a).apply_t(Box::new(SinFn(0)));
+
+    let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    let mut derivatives = vec![sin_a];
+    let mut next = sin_a;
+    write!(csv, "x, $\\sin(x)$, ").unwrap();
+    for i in 1..4 {
+        next = next.gen_graph(&a).unwrap();
+        derivatives.push(next);
+        write!(csv, "$(d^{i} \\sin(-x^2)/(d x^{i})$, ").unwrap();
+    }
+    writeln!(csv, "").unwrap();
+
+    for i in -50..50 {
+        let x = i as f64 * 0.1;
+        a.set(x).unwrap();
+        write!(csv, "{x}, ").unwrap();
+        for d in &derivatives {
+            write!(csv, "{}, ", d.eval()).unwrap();
+        }
+        writeln!(csv, "").unwrap();
+    }
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
+    derivatives
+        .last()
+        .unwrap()
+        .dot_builder()
+        .show_values(true)
+        .dot(&mut writer)
+        .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod dnum;
 mod dvec;
 pub mod error;
 mod rc_term;
-mod tape;
+pub mod tape;
 mod tensor;
 mod term;
 mod unary_fn;

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -416,6 +416,11 @@ fn add_node<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, name: String, value: TapeVa
     new_idx as u32
 }
 
+pub fn add_value<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, val: T) -> u32 {
+    let name = format!("{val}");
+    add_node(nodes, name, TapeValue::Value(val))
+}
+
 fn add_add<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
     let name = format!(
         "{} + {}",
@@ -424,7 +429,7 @@ fn add_add<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
     add_node(nodes, name, TapeValue::Add(lhs, rhs))
 }
 
-fn add_sub<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
+pub fn add_sub<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
     let name = format!(
         "{} - {}",
         nodes[lhs as usize].name, nodes[rhs as usize].name

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -588,7 +588,7 @@ fn gen_graph<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, idx: u32, wrt: u32) -> Opt
                 taken_f
                     .as_ref()
                     .unwrap()
-                    .gen_graph(nodes, idx, term, derived)
+                    .gen_graph(nodes, term, idx, derived)
             });
             if let UnaryFn(UnaryFnPayload { ref mut f, .. }) = nodes[idx as usize].value {
                 *f = taken_f;

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -422,7 +422,7 @@ pub fn add_value<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, val: T) -> u32 {
     add_node(nodes, name, TapeValue::Value(val))
 }
 
-fn add_add<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
+pub fn add_add<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, lhs: u32, rhs: u32) -> u32 {
     let name = format!(
         "{} + {}",
         nodes[lhs as usize].name, nodes[rhs as usize].name

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -317,6 +317,7 @@ impl<'a, T: Tensor + 'static> TapeTerm<'a, T> {
             show_values: false,
             vertical: false,
             hilight: None,
+            precision: 2,
         }
     }
 
@@ -645,6 +646,7 @@ pub struct TapeDotBuilder<'a, T: Default> {
     show_values: bool,
     vertical: bool,
     hilight: Option<u32>,
+    precision: usize,
 }
 
 impl<'a, T: Tensor> TapeDotBuilder<'a, T> {
@@ -662,6 +664,12 @@ impl<'a, T: Tensor> TapeDotBuilder<'a, T> {
     /// Set a term to show highlighted border around it.
     pub fn highlights(mut self, term: u32) -> Self {
         self.hilight = Some(term);
+        self
+    }
+
+    /// Set floating point precision after decimal point
+    pub fn precision(mut self, precision: usize) -> Self {
+        self.precision = precision;
         self
     }
 
@@ -695,15 +703,16 @@ impl<'a, T: Tensor> TapeDotBuilder<'a, T> {
                 ""
             };
             let label = if self.show_values {
+                let formatter = |v| format!("{v:.precision$}", precision = self.precision);
                 format!(
                     "\\ndata:{}, grad:{}",
                     term.data
                         .as_ref()
-                        .map(|v| format!("{v}"))
+                        .map(formatter)
                         .unwrap_or_else(|| "None".into()),
                     term.grad
                         .as_ref()
-                        .map(|v| format!("{v:0.2}"))
+                        .map(formatter)
                         .unwrap_or_else(|| "None".into())
                 )
             } else {

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -453,6 +453,22 @@ fn add_neg<T: Tensor>(nodes: &mut Vec<TapeNode<T>>, node: u32) -> u32 {
     add_node(nodes, name, TapeValue::Neg(node))
 }
 
+pub fn add_unary_fn<T: Tensor>(
+    nodes: &mut Vec<TapeNode<T>>,
+    f: Box<dyn UnaryFn<T>>,
+    node: u32,
+) -> u32 {
+    let name = format!("{}({})", f.name(), nodes[node as usize].name);
+    add_node(
+        nodes,
+        name,
+        TapeValue::UnaryFn(UnaryFnPayload {
+            term: node,
+            f: Some(f),
+        }),
+    )
+}
+
 fn gen_graph<T: Tensor>(
     nodes: &mut Vec<TapeNode<T>>,
     derive_map: &mut HashMap<u32, u32>,

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -527,7 +527,7 @@ fn gen_graph<T: Tensor>(
                 _ => None,
             }
         }
-        Neg(term) => todo!(),
+        Neg(term) => gen_graph(nodes, derive_map, term, wrt).map(|node| add_neg(nodes, node)),
         UnaryFn(UnaryFnPayload { .. }) => todo!(),
     }
 }

--- a/src/unary_fn.rs
+++ b/src/unary_fn.rs
@@ -1,3 +1,5 @@
+use crate::tape::TapeNode;
+
 /// A trait that represents an unary operation on a value.
 /// It needs to implement a transformation of the value, the gradient
 /// and its reverse transformation (transposition).
@@ -7,6 +9,18 @@ pub trait UnaryFn<T> {
     fn grad(&self, data: T) -> T;
     fn t(&self, data: T) -> T {
         data
+    }
+
+    /// A method to generate a graph node that represents differentiation of this node.
+    /// It takes input and its derived node indices as the arguments.
+    fn gen_graph(
+        &self,
+        _nodes: &mut Vec<TapeNode<T>>,
+        _this: u32,
+        _input: u32,
+        _derived: u32,
+    ) -> Option<u32> {
+        None
     }
 }
 

--- a/src/unary_fn.rs
+++ b/src/unary_fn.rs
@@ -12,12 +12,16 @@ pub trait UnaryFn<T> {
     }
 
     /// A method to generate a graph node that represents differentiation of this node.
-    /// It takes input and its derived node indices as the arguments.
+    /// It takes 3 parameters:
+    ///
+    /// * `input` - a node that comes as an input variable of this node, e.g. x in exp(x).
+    /// * `output` - a node that outputs the evaluated result, e.g. exp(x) itself in exp(x).
+    /// * `derived` - a node representing a derived input, that is, x'.
     fn gen_graph(
         &self,
         _nodes: &mut Vec<TapeNode<T>>,
-        _this: TapeIndex,
         _input: TapeIndex,
+        _output: TapeIndex,
         _derived: TapeIndex,
     ) -> Option<TapeIndex> {
         None

--- a/src/unary_fn.rs
+++ b/src/unary_fn.rs
@@ -1,4 +1,4 @@
-use crate::tape::TapeNode;
+use crate::tape::{TapeIndex, TapeNode};
 
 /// A trait that represents an unary operation on a value.
 /// It needs to implement a transformation of the value, the gradient
@@ -16,10 +16,10 @@ pub trait UnaryFn<T> {
     fn gen_graph(
         &self,
         _nodes: &mut Vec<TapeNode<T>>,
-        _this: u32,
-        _input: u32,
-        _derived: u32,
-    ) -> Option<u32> {
+        _this: TapeIndex,
+        _input: TapeIndex,
+        _derived: TapeIndex,
+    ) -> Option<TapeIndex> {
         None
     }
 }


### PR DESCRIPTION
Fixes #7 

# Known issues

##  Multiplicative identity value "1" for tensor types

Tensor types can have various shapes, so a "1" (obtained by `T::one()` method) is not necessarily compatible with all of them. If we introduce broadcasting rule, we won't be able to track back the gradient in reverse mode.

It is more likely to become a problem in `gen_graph` facilities, because it can produce "1" constants a lot. I don't have a good idea to solve it right now, so I wll leave it for this PR. Probably I will add a special type `TapeValue::Const` to not backpropagate gradient and allow broadcasting for these nodes.

## `RcTerm` implementation

We implement `gen_graph` facilities in `TapeTerm` only. We will backport it to `RcTerm` once we have a set of complete features.

