### PR TITLE
Custom Binary Functions Support

### DIFF
--- a/examples/tape_gen_graph_atan2.rs
+++ b/examples/tape_gen_graph_atan2.rs
@@ -1,0 +1,93 @@
+//! gen_graph example with polynomials.
+use std::io::Write;
+
+use rustograd::{
+    tape::{add_add, add_div, add_mul, add_neg, TapeIndex, TapeNode},
+    BinaryFn, Tape,
+};
+
+struct Atan2Fn;
+
+impl BinaryFn<f64> for Atan2Fn {
+    fn name(&self) -> String {
+        format!("atan2")
+    }
+
+    fn f(&self, lhs: f64, rhs: f64) -> f64 {
+        lhs.atan2(rhs)
+    }
+
+    fn grad(&self, lhs: f64, rhs: f64) -> (f64, f64) {
+        let denom = lhs.powi(2) + rhs.powi(2);
+        (rhs / denom, -lhs / denom)
+    }
+
+    fn t(&self, data: f64) -> (f64, f64) {
+        (data, data)
+    }
+
+    fn gen_graph(
+        &self,
+        nodes: &mut Vec<TapeNode<f64>>,
+        lhs: TapeIndex,
+        rhs: TapeIndex,
+        _output: TapeIndex,
+        _l_derived: TapeIndex,
+        _r_derived: TapeIndex,
+    ) -> Option<TapeIndex> {
+        let lhs2 = add_mul(nodes, lhs, lhs);
+        let rhs2 = add_mul(nodes, rhs, rhs);
+        let denom = add_add(nodes, lhs2, rhs2);
+        let dlhs = add_div(nodes, rhs, denom);
+        let drhs = add_div(nodes, lhs, denom);
+        let drhs = add_neg(nodes, drhs);
+        Some(add_add(nodes, dlhs, drhs))
+    }
+}
+
+fn main() {
+    let tape = Tape::new();
+    let a = tape.term("a", 1.23);
+    let b = tape.term("b", 0.93);
+    let atan2_ab = (a).apply_bin(b, Box::new(Atan2Fn));
+
+    let mut csv = std::io::BufWriter::new(std::fs::File::create("data.csv").unwrap());
+    let mut derivatives = vec![atan2_ab];
+    let mut next = atan2_ab;
+    write!(csv, "\"theta\", \"atan2(y x)\", \"d (atan2(y x)) / d y (derive)\", \"d (atan2(y x)) / d x (derive)\", \"d (atan2(y x)) / d y (backprop)\", \"d (atan2(y x)) / d x (backprop)\", ").unwrap();
+    for i in 1..4 {
+        let Some(next_i) = next.gen_graph(&a) else { break };
+        next = next_i;
+        derivatives.push(next);
+        write!(csv, "$(d^{i} x^3)/(d x^{i})$, ").unwrap();
+    }
+    writeln!(csv, "").unwrap();
+
+    for i in 0..100 {
+        let angle = i as f64 * std::f64::consts::PI * 2. / 100.;
+        a.set(angle.sin()).unwrap();
+        b.set(angle.cos()).unwrap();
+        write!(csv, "{angle}, ").unwrap();
+        let eval = atan2_ab.eval();
+        write!(csv, "{eval}, ").unwrap();
+        let grad_a = atan2_ab.derive(&a).unwrap();
+        write!(csv, "{grad_a}, ").unwrap();
+        let grad_b = atan2_ab.derive(&b).unwrap();
+        write!(csv, "{grad_b}, ").unwrap();
+        atan2_ab.backprop().unwrap();
+        write!(csv, "{}, {}, ", a.grad().unwrap(), b.grad().unwrap()).unwrap();
+        for d in &derivatives {
+            write!(csv, "{}, ", d.eval()).unwrap();
+        }
+        writeln!(csv, "").unwrap();
+    }
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create("graph.dot").unwrap());
+    derivatives
+        .last()
+        .unwrap()
+        .dot_builder()
+        .show_values(true)
+        .dot(&mut writer)
+        .unwrap();
+}

--- a/examples/tape_gen_graph_atan2.rs
+++ b/examples/tape_gen_graph_atan2.rs
@@ -35,13 +35,13 @@ impl BinaryFn<f64> for Atan2Fn {
         _l_derived: TapeIndex,
         _r_derived: TapeIndex,
     ) -> Option<TapeIndex> {
-        let lhs2 = add_mul(nodes, lhs, lhs);
-        let rhs2 = add_mul(nodes, rhs, rhs);
-        let denom = add_add(nodes, lhs2, rhs2);
-        let dlhs = add_div(nodes, rhs, denom);
-        let drhs = add_div(nodes, lhs, denom);
-        let drhs = add_neg(nodes, drhs);
-        Some(add_add(nodes, dlhs, drhs))
+        let lhs2 = add_mul(nodes, lhs, lhs, true);
+        let rhs2 = add_mul(nodes, rhs, rhs, true);
+        let denom = add_add(nodes, lhs2, rhs2, true);
+        let dlhs = add_div(nodes, rhs, denom, true);
+        let drhs = add_div(nodes, lhs, denom, true);
+        let drhs = add_neg(nodes, drhs, true);
+        Some(add_add(nodes, dlhs, drhs, true))
     }
 }
 
@@ -56,7 +56,9 @@ fn main() {
     let mut next = atan2_ab;
     write!(csv, "\"theta\", \"atan2(y x)\", \"d (atan2(y x)) / d y (derive)\", \"d (atan2(y x)) / d x (derive)\", \"d (atan2(y x)) / d y (backprop)\", \"d (atan2(y x)) / d x (backprop)\", ").unwrap();
     for i in 1..4 {
-        let Some(next_i) = next.gen_graph(&a) else { break };
+        let Some(next_i) = next.gen_graph(&a) else {
+            break;
+        };
         next = next_i;
         derivatives.push(next);
         write!(csv, "$(d^{i} x^3)/(d x^{i})$, ").unwrap();

--- a/src/binary_fn.rs
+++ b/src/binary_fn.rs
@@ -6,7 +6,7 @@ use crate::tape::{TapeIndex, TapeNode};
 pub trait BinaryFn<T> {
     fn name(&self) -> String;
     fn f(&self, lhs: T, rhs: T) -> T;
-    fn grad(&self, lhs: T, rhs: T) -> T;
+    fn grad(&self, lhs: T, rhs: T) -> (T, T);
     fn t(&self, data: T) -> (T, T);
     fn gen_graph(
         &self,
@@ -24,7 +24,7 @@ pub trait BinaryFn<T> {
 pub(crate) struct PtrBinaryFn<T> {
     pub name: String,
     pub f: fn(T, T) -> T,
-    pub grad: fn(T, T) -> T,
+    pub grad: fn(T, T) -> (T, T),
     pub t: fn(T) -> (T, T),
 }
 
@@ -35,7 +35,7 @@ impl<T> BinaryFn<T> for PtrBinaryFn<T> {
     fn f(&self, lhs: T, rhs: T) -> T {
         (self.f)(lhs, rhs)
     }
-    fn grad(&self, lhs: T, rhs: T) -> T {
+    fn grad(&self, lhs: T, rhs: T) -> (T, T) {
         (self.grad)(lhs, rhs)
     }
     fn t(&self, data: T) -> (T, T) {

--- a/src/binary_fn.rs
+++ b/src/binary_fn.rs
@@ -1,3 +1,5 @@
+use crate::tape::{TapeIndex, TapeNode};
+
 /// A trait that represents a binary operation on a value.
 /// It needs to implement a transformation of the value, the gradient
 /// and its reverse transformation (transposition).
@@ -6,6 +8,17 @@ pub trait BinaryFn<T> {
     fn f(&self, lhs: T, rhs: T) -> T;
     fn grad(&self, lhs: T, rhs: T) -> T;
     fn t(&self, data: T) -> (T, T);
+    fn gen_graph(
+        &self,
+        _node: &mut Vec<TapeNode<T>>,
+        _lhs: TapeIndex,
+        _rhs: TapeIndex,
+        _output: TapeIndex,
+        _l_derived: TapeIndex,
+        _r_derived: TapeIndex,
+    ) -> Option<TapeIndex> {
+        None
+    }
 }
 
 pub(crate) struct PtrBinaryFn<T> {

--- a/src/binary_fn.rs
+++ b/src/binary_fn.rs
@@ -1,0 +1,31 @@
+/// A trait that represents a binary operation on a value.
+/// It needs to implement a transformation of the value, the gradient
+/// and its reverse transformation (transposition).
+pub trait BinaryFn<T> {
+    fn name(&self) -> String;
+    fn f(&self, lhs: T, rhs: T) -> T;
+    fn grad(&self, lhs: T, rhs: T) -> T;
+    fn t(&self, data: T) -> (T, T);
+}
+
+pub(crate) struct PtrBinaryFn<T> {
+    pub name: String,
+    pub f: fn(T, T) -> T,
+    pub grad: fn(T, T) -> T,
+    pub t: fn(T) -> (T, T),
+}
+
+impl<T> BinaryFn<T> for PtrBinaryFn<T> {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+    fn f(&self, lhs: T, rhs: T) -> T {
+        (self.f)(lhs, rhs)
+    }
+    fn grad(&self, lhs: T, rhs: T) -> T {
+        (self.grad)(lhs, rhs)
+    }
+    fn t(&self, data: T) -> (T, T) {
+        (self.t)(data)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod binary_fn;
 mod dnum;
 mod dnum_n2;
 mod dvec;
@@ -8,6 +9,7 @@ mod tensor;
 mod term;
 mod unary_fn;
 
+pub use binary_fn::BinaryFn;
 pub use dnum::Dnum;
 pub use dnum_n2::Dnum2;
 pub use dvec::Dvec;

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -188,6 +188,16 @@ impl<T: Tensor> Tape<T> {
     }
 }
 
+impl<T: Tensor + std::fmt::Debug> Tape<T> {
+    pub fn dump_nodes(&self) {
+        let nodes = self.nodes.borrow();
+        let n = nodes.len();
+        for (i, node) in nodes.iter().enumerate() {
+            println!("[{i}/{n}]: {node:?}");
+        }
+    }
+}
+
 impl<'a, T: Tensor> std::ops::Add for TapeTerm<'a, T> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
@@ -384,7 +394,10 @@ impl<'a, T: Tensor + 'static> TapeTerm<'a, T> {
 
     pub fn apply_bin(&self, rhs: TapeTerm, f: Box<dyn BinaryFn<T>>) -> Self {
         let self_name = self.tape.nodes.borrow()[self.idx as usize].name.clone();
+        #[cfg(feature = "expr_name")]
         let name = format!("{}({})", f.name(), self_name);
+        #[cfg(not(feature = "expr_name"))]
+        let name = self_name;
         self.tape.term_name(
             name,
             TapeValue::BinaryFn(BinaryFnPayload {


### PR DESCRIPTION
Fixes #10 

Binary functions are generalization of common operations like Add or Mul. The user has to implement a new trait `BinaryFn` defined as below.

```rust
pub trait BinaryFn<T> {
    fn name(&self) -> String;
    fn f(&self, lhs: T, rhs: T) -> T;
    fn grad(&self, lhs: T, rhs: T) -> (T, T);
    fn t(&self, data: T) -> (T, T);
    fn gen_graph(
        &self,
        _node: &mut Vec<TapeNode<T>>,
        _lhs: TapeIndex,
        _rhs: TapeIndex,
        _output: TapeIndex,
        _l_derived: TapeIndex,
        _r_derived: TapeIndex,
    ) -> Option<TapeIndex> {
        None
    }
}
```

The `name` and `f` methods are the same as `UnarfyFn`..

The `grad` method is a bit interesting. Since it has to return gradient to 2 input values, you need to return 2 values, unlike `UnaryFn`.

The `t` method is important, although I don't know how to name it properly. It is a transformation of gradient values to each of input variable.

The `gen_graph` method is the most complicated, since it can take 2 inputs and their derived nodes, but it should be pretty straightforward if you aleady know `UnaryFn`.
